### PR TITLE
Add ability to add more images via environment variable HUBOT_MORE_SOON_IMAGES

### DIFF
--- a/soon.coffee
+++ b/soon.coffee
@@ -48,6 +48,8 @@ images = [
   "http://media.giphy.com/media/uf6z9MY3iCdSE/giphy.gif"
 ]
 
+images = images.concat process.env.HUBOT_MORE_SOON_IMAGES.split ',' if process.env.HUBOT_MORE_SOON_IMAGES
+
 module.exports = (robot) ->
   robot.hear /\bso[o]+n\b/i, (msg) ->
     msg.send msg.random images


### PR DESCRIPTION
Useful for adding images that embody 'soon' but are more of an inside joke and would not make sense to others people or may be inappropriate for some groups. Like a tabletop RPG based soon image in a chat group about FPS games or vice versa.
